### PR TITLE
fix CRLF support of runtest.py (#640)

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -395,9 +395,6 @@ while t.next():
                                 timeout=args.test_timeout)
         #print "%s,%s,%s" % (idx, repr(p.before), repr(p.after))
 
-        if os.name == 'nt':
-            res = res.replace('\x16', '\r')
-
         if (res == None):
             log(" -> TIMEOUT (line %d)" % t.line_num)
             raise TestTimeout("TIMEOUT (line %d)" % t.line_num)

--- a/runtest.py
+++ b/runtest.py
@@ -391,6 +391,10 @@ while t.next():
         res = r.read_to_prompt(['\r\n[^\s()<>]+> ', '\n[^\s()<>]+> '],
                                 timeout=args.test_timeout)
         #print "%s,%s,%s" % (idx, repr(p.before), repr(p.after))
+
+        if os.name == 'nt':
+            res = res.replace('\x16', '\r')
+
         if (res == None):
             log(" -> TIMEOUT (line %d)" % t.line_num)
             raise TestTimeout("TIMEOUT (line %d)" % t.line_num)

--- a/runtest.py
+++ b/runtest.py
@@ -241,7 +241,10 @@ class TestReader:
     def __init__(self, test_file):
         self.line_num = 0
         f = open(test_file, newline='') if IS_PY_3 else open(test_file)
-        self.data = f.read().split('\n')
+        
+        # See: https://github.com/kanaka/mal/pull/640
+        self.data = f.read().replace('\r\n', '\n').replace('\r', '\n').split('\n')
+        
         self.soft = False
         self.deferrable = False
         self.optional = False


### PR DESCRIPTION
See: [#640](https://github.com/kanaka/mal/pull/640)